### PR TITLE
🔧🎨 add formatter in gh actions

### DIFF
--- a/.github/workflows/format-java.yml
+++ b/.github/workflows/format-java.yml
@@ -20,10 +20,8 @@ jobs:
           mvn compile
           mvn formatter:format
       - name: Commit changes
-        uses: EndBug/add-and-commit@v7
+        uses: EndBug/add-and-commit@v9
         with:
-          author_name: ${{ github.actor }}
-          author_email: ${{ github.actor }}@users.noreply.github.com
+          default_author: 'github_actions'
           message: '🎨 Format Java code'
-          add: '.'
-        
+

--- a/.github/workflows/format-java.yml
+++ b/.github/workflows/format-java.yml
@@ -1,0 +1,29 @@
+name: Format Java Workflow
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  compile-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'maven'
+      - name: Testing application
+        run: |
+          mvn compile
+          mvn formatter:format
+      - name: Commit changes
+        uses: EndBug/add-and-commit@v7
+        with:
+          author_name: ${{ github.actor }}
+          author_email: ${{ github.actor }}@users.noreply.github.com
+          message: '🎨 Format Java code'
+          add: '.'
+        

--- a/pom.xml
+++ b/pom.xml
@@ -189,6 +189,19 @@
 					</includes>
 				</configuration>
 			</plugin>
+
+			<plugin>
+				<groupId>net.revelc.code.formatter</groupId>
+				<artifactId>formatter-maven-plugin</artifactId>
+				<version>2.22.0</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>format</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 
 		<resources>


### PR DESCRIPTION
# Description 📣

Add Java formatter on compilation & execute it in github actions

```xml
<plugin>
	<groupId>net.revelc.code.formatter</groupId>
	<artifactId>formatter-maven-plugin</artifactId>
	<version>2.22.0</version>
	<executions>
  		<execution>
    			<goals>
      				<goal>format</goal>
			</goals>
  		</execution>
	</executions>
</plugin>
```

## Type 🎨

[ ] Bug fix (non-breaking change which fixes an issue)
[x] New feature (non-breaking change which adds functionality)
[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
[ ] This change requires a documentation update


